### PR TITLE
Fix#14 Prevent from a crash when no footer or no header.

### DIFF
--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.h
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.h
@@ -16,11 +16,30 @@
  * Currently this class does not support supplementary or decoration views.
  *
  */
-@interface NHBalancedFlowLayout : UICollectionViewFlowLayout
+@interface NHBalancedFlowLayout : UICollectionViewLayout
 
 // The preferred size for each row measured in the scroll direction
 @property (nonatomic) CGFloat preferredRowSize;
 
+// The size of each section's header. This maybe dynamically adjusted
+// per section via the protocol method referenceSizeForHeaderInSection.
+@property (nonatomic) CGSize headerReferenceSize;
+
+// The size of each section's header. This maybe dynamically adjusted
+// per section via the protocol method referenceSizeForFooterInSection.
+@property (nonatomic) CGSize footerReferenceSize;
+
+// The margins used to lay out content in a section.
+@property (nonatomic) UIEdgeInsets sectionInset;
+
+// The minimum spacing to use between lines of items in the grid.
+@property (nonatomic) CGFloat minimumLineSpacing;
+
+// The minimum spacing to use between items in the same row.
+@property (nonatomic) CGFloat minimumInteritemSpacing;
+
+// The scroll direction of the grid.
+@property (nonatomic) UICollectionViewScrollDirection scrollDirection;
 
 @end
 

--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.m
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.m
@@ -215,6 +215,7 @@
         attributes.frame = [self footerFrameForSection:indexPath.section];
     }
     
+    // If there is no header or footer, we need to return nil to prevent a crash from UICollectionView private methods.
     if(CGRectIsEmpty(attributes.frame))
     {
         attributes = nil;
@@ -384,6 +385,41 @@
 - (void)setPreferredRowSize:(CGFloat)preferredRowHeight
 {
     _preferredRowSize = preferredRowHeight;
+    
+    [self invalidateLayout];
+}
+
+- (void)setSectionInset:(UIEdgeInsets)sectionInset
+{
+    _sectionInset = sectionInset;
+    
+    [self invalidateLayout];
+}
+
+- (void)setMinimumLineSpacing:(CGFloat)minimumLineSpacing
+{
+    _minimumLineSpacing = minimumLineSpacing;
+    
+    [self invalidateLayout];
+}
+
+- (void)setMinimumInteritemSpacing:(CGFloat)minimumInteritemSpacing
+{
+    _minimumInteritemSpacing = minimumInteritemSpacing;
+    
+    [self invalidateLayout];
+}
+
+- (void)setHeaderReferenceSize:(CGSize)headerReferenceSize
+{
+    _headerReferenceSize = headerReferenceSize;
+    
+    [self invalidateLayout];
+}
+
+- (void)setFooterReferenceSize:(CGSize)footerReferenceSize
+{
+    _footerReferenceSize = footerReferenceSize;
     
     [self invalidateLayout];
 }


### PR DESCRIPTION
This methods should return nil for no footer or no header:

```
- (UICollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath;
```

And this method, declared in UICollectionViewDatasource (implemented in the Demo project) :

```
- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
{
    UICollectionReusableView *view = nil;

    view = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:@"HeaderView" forIndexPath:indexPath];

     if ([kind isEqualToString:UICollectionElementKindSectionFooter]) {
        view.frame = CGRectZero;
    }
    return view;
}
```

Note: The crash is not in this library, but in _createPreparedSupplementaryViewForElementOfKind: which is a private API of UICollectionView.
