### PR TITLE
Do not add layout attributes for header or footer if size is zero

### DIFF
--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.m
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.m
@@ -286,6 +286,12 @@
 - (void)setFrames:(CGRect *)frames forItemsInSection:(NSInteger)section numberOfRows:(NSUInteger)numberOfRows sectionOffset:(CGPoint)sectionOffset sectionSize:(CGSize *)sectionSize
 {
     NSArray *weights = [self weightsForItemsInSection:section];
+    
+    if (weights.count == 0) {
+        *sectionSize = CGSizeZero;
+        return;
+    }
+
     NSArray *partition = [NHLinearPartition linearPartitionForSequence:weights numberOfPartitions:numberOfRows];
     
     int i = 0;


### PR DESCRIPTION
Header and footer always have width of the view, so comparison with CGSizeZero always fails. This causes crash when calling [UICollectionView insertSections:].
