### PR TITLE
Added scalesItemToFill property

### DIFF
--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.h
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.h
@@ -21,6 +21,10 @@
 // The preferred size for each row measured in the scroll direction
 @property (nonatomic) CGFloat preferredRowSize;
 
+// The option to scale the item's prefered size to fill the preferred
+// row size by changing the aspect ratio of the item if necessary.
+@property (nonatomic) BOOL scalesItemToFill;
+
 // The size of each section's header. This maybe dynamically adjusted
 // per section via the protocol method referenceSizeForHeaderInSection.
 @property (nonatomic) CGSize headerReferenceSize;

--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.h
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.h
@@ -21,7 +21,7 @@
 // The preferred size for each row measured in the scroll direction
 @property (nonatomic) CGFloat preferredRowSize;
 
-// The option to scale the item's prefered size to fill the preferred
+// The option to scale the item's preferred size to fill the preferred
 // row size by changing the aspect ratio of the item if necessary.
 @property (nonatomic) BOOL scalesItemToFill;
 

--- a/NHBalancedFlowLayout/NHBalancedFlowLayout.m
+++ b/NHBalancedFlowLayout/NHBalancedFlowLayout.m
@@ -308,10 +308,10 @@
             
             CGSize actualSize = CGSizeZero;
             if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
-                actualSize = CGSizeMake(roundf(rowSize / summedRatios * (preferredSize.width / preferredSize.height)), roundf(rowSize / summedRatios));
+                actualSize = CGSizeMake(roundf(rowSize / summedRatios * (preferredSize.width / preferredSize.height)), self.scalesItemToFill && self.preferredRowSize != 0 ? self.preferredRowSize : roundf(rowSize / summedRatios));
             }
             else {
-                actualSize = CGSizeMake(roundf(rowSize / summedRatios), roundf(rowSize / summedRatios * (preferredSize.height / preferredSize.width)));
+                actualSize = CGSizeMake(self.scalesItemToFill && self.preferredRowSize != 0 ? self.preferredRowSize : roundf(rowSize / summedRatios), roundf(rowSize / summedRatios * (preferredSize.height / preferredSize.width)));
             }
             
             CGRect frame = CGRectMake(offset.x, offset.y, actualSize.width, actualSize.height);
@@ -384,6 +384,13 @@
 - (void)setPreferredRowSize:(CGFloat)preferredRowHeight
 {
     _preferredRowSize = preferredRowHeight;
+    
+    [self invalidateLayout];
+}
+
+- (void)setScalesItemToFill:(BOOL)scalesItemToFill
+{
+    _scalesItemToFill = scalesItemToFill;
     
     [self invalidateLayout];
 }


### PR DESCRIPTION
It appears that NHBalancedFlowLayout scales item sizes up to fit the row width while preserving their aspect ratios. This produces different row heights, which makes total sense for displaying images.  In my project, however, I am laying out text contents and having a fixed row height would make more sense. Therefore, I added a property `scalesItemToFill` that acts similarly to UIViewContentModeScaleToFill. It changes the aspect ratios of items' preferred size to fill a fixed row height (provided by `preferredRowSize`).

### Before
<img src="https://www.dropbox.com/s/9s1z487p3p3obun/iOS%20Simulator%20Screen%20Shot%20Nov%2016%2C%202014%2C%2010.28.13%20PM.png?dl=1" alt="before" width=350>

### After
<img src="https://www.dropbox.com/s/wih7zsk8ommnu9b/iOS%20Simulator%20Screen%20Shot%20Nov%2016%2C%202014%2C%2010.28.30%20PM.png?dl=1" alt="after" width=350>